### PR TITLE
Additional Logging for net-pos plugin 

### DIFF
--- a/pwnagotchi/plugins/default/net-pos.py
+++ b/pwnagotchi/plugins/default/net-pos.py
@@ -73,15 +73,15 @@ class NetPos(plugins.Plugin):
                     try:
                         geo_data = self._get_geo_data(np_file)  # returns json obj
                     except requests.exceptions.RequestException as req_e:
-                        logging.error("NET-POS: %s", req_e)
+                        logging.error("NET-POS: %s - RequestException: %s", np_file, req_e)
                         self.skip += np_file
                         continue
                     except json.JSONDecodeError as js_e:
-                        logging.error("NET-POS: %s", js_e)
+                        logging.error("NET-POS: %s - JSONDecodeError: %s", np_file, js_e)
                         self.skip += np_file
                         continue
                     except OSError as os_e:
-                        logging.error("NET-POS: %s", os_e)
+                        logging.error("NET-POS: %s - OSError: %s", np_file, os_e)
                         self.skip += np_file
                         continue
 


### PR DESCRIPTION
I currently have some broken net-pos files on my device and the logging does not provide enough information to find the invalid files. I'd suggest to log the path.

## Description
Currently the net-pos plugin only logs out the Error message but not which error happened and on which file. 

## Motivation and Context
- [ ] I have raised an issue to propose this change ([required]

## How Has This Been Tested?
manually

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
